### PR TITLE
Fix generate_course_structure command.

### DIFF
--- a/openedx/core/djangoapps/content/course_structures/management/commands/generate_course_structure.py
+++ b/openedx/core/djangoapps/content/course_structures/management/commands/generate_course_structure.py
@@ -42,7 +42,7 @@ class Command(BaseCommand):
                 # TODO Future improvement: Use .delay(), add return value to ResultSet, and wait for execution of
                 # all tasks using ResultSet.join(). I (clintonb) am opting not to make this improvement right now
                 # as I do not have time to test it fully.
-                update_course_structure.apply(unicode(course_key))
+                update_course_structure.apply(args=[unicode(course_key)])
             except Exception as ex:
                 log.exception('An error occurred while generating course structure for %s: %s',
                               unicode(course_key), ex.message)


### PR DESCRIPTION
Fixe le script generate_course_structure permettant de créer un entrée dans la table course_structure.
Table nécessaire à l’exécution de ´Generate problem grade report´ depuis le dashboard enseignant.
Ticket https://fun.plan.io/issues/1568.
