### PR TITLE
Fix incorrect status in optioninput problem templates.

### DIFF
--- a/common/lib/capa/capa/templates/optioninput.html
+++ b/common/lib/capa/capa/templates/optioninput.html
@@ -12,13 +12,12 @@
       % endfor
     </select>
 
-  <span id="answer_${id}"></span>  
   <span class="status ${status.classname}"
       id="status_${id}"
       aria-describedby="input_${id}">
     <span class="sr">${value|h} - ${status.display_name}</span>
   </span>
-
+  <p class="answer" id="answer_${id}"></p>  
   % if msg:
       <span class="message">${msg|n}</span>
   % endif


### PR DESCRIPTION
Avant :

![before-optioninput](https://cloud.githubusercontent.com/assets/2971857/9637253/11e5549a-51a0-11e5-9c1e-b20c398992e7.png)

Après:
![after-optioninput](https://cloud.githubusercontent.com/assets/2971857/9637256/199fc3b4-51a0-11e5-965d-e2b118fee3c3.png)

Ticket
https://fun.plan.io/issues/1683
