### PR TITLE
Fix overflow in drag and drop label.

### DIFF
--- a/common/static/js/capa/drag_and_drop/draggables.js
+++ b/common/static/js/capa/drag_and_drop/draggables.js
@@ -289,8 +289,8 @@ define(['js/capa/drag_and_drop/draggable_events', 'js/capa/drag_and_drop/draggab
 
                 draggableObj.iconEl.appendTo(draggableObj.containerEl);
 
-                draggableObj.iconWidth = draggableObj.iconEl.width();
-                draggableObj.iconHeight = draggableObj.iconEl.height();
+                draggableObj.iconWidth = draggableObj.iconEl.width() + (draggableObj.iconElPadding * 2) + 2;
+                draggableObj.iconHeight = draggableObj.iconEl.height() + 2;
                 draggableObj.iconWidthSmall = draggableObj.iconWidth;
                 draggableObj.iconHeightSmall = draggableObj.iconHeight;
 


### PR DESCRIPTION
Avant:

![fixed-overflow-drag-drop-before](https://cloud.githubusercontent.com/assets/2971857/9764528/e0885e54-570f-11e5-91e2-773ed80c34d9.png)
Après:

![fixed-overflow-drag-drop-after](https://cloud.githubusercontent.com/assets/2971857/9764538/e950ab22-570f-11e5-921e-b5bdad4fb888.png)

Ticket https://fun.plan.io/issues/1643
