### PR TITLE
Fix (un)enrollment email default language

### DIFF
--- a/lms/djangoapps/instructor/enrollment.py
+++ b/lms/djangoapps/instructor/enrollment.py
@@ -395,6 +395,7 @@ def render_message_to_string(subject_template, message_template, param_dict, lan
     Returns two strings that correspond to the rendered, translated email
     subject and message.
     """
+    language = language or settings.LANGUAGE_CODE
     with override_language(language):
         return get_subject_and_message(subject_template, message_template, param_dict)
 

--- a/lms/djangoapps/instructor/tests/test_api_email_localization.py
+++ b/lms/djangoapps/instructor/tests/test_api_email_localization.py
@@ -5,13 +5,14 @@ Unit tests for the localization of emails sent by instructor.api methods.
 
 from django.core import mail
 from django.core.urlresolvers import reverse
+from django.test.utils import override_settings
 from nose.plugins.attrib import attr
 
 from courseware.tests.factories import InstructorFactory
 from lang_pref import LANGUAGE_KEY
 from student.models import CourseEnrollment
 from student.tests.factories import UserFactory
-from openedx.core.djangoapps.user_api.preferences.api import set_user_preference
+from openedx.core.djangoapps.user_api.preferences.api import set_user_preference, delete_user_preference
 from xmodule.modulestore.tests.factories import CourseFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 
@@ -86,3 +87,11 @@ class TestInstructorAPIEnrollmentEmailLocalization(ModuleStoreTestCase):
         # Student is unknown, so the platform language should be used
         self.update_enrollement("enroll", "newuser@hotmail.com")
         self.check_outbox("You have been")
+
+
+    @override_settings(LANGUAGE_CODE="fr")
+    def test_user_without_preference_receives_email_in_french(self):
+        delete_user_preference(self.student, LANGUAGE_KEY)
+        self.update_enrollement("enroll", self.student.email)
+
+        self.check_outbox_is_french()


### PR DESCRIPTION
When one or many users are sent an enrollment or unenrollment email via
the teacher subscription form, the emails are written in the user
language. If the user has no preferred language, e.g: when the user does
not exist, the platform language is supposed to be selected. In
practice, the emails were not being translated at all.

This closes issue #2199.
