### PR TITLE
Change student template to display old receipts in the dashboard

### DIFF
--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -14,7 +14,6 @@ from django.core.urlresolvers import reverse
   cert_name_long = settings.CERT_NAME_LONG
 %>
 
-
 <%block name="pagetitle">${_("Dashboard")}</%block>
 <%block name="bodyclass">view-dashboard is-authenticated</%block>
 <%block name="nav_skip">#my-courses</%block>
@@ -166,6 +165,13 @@ from django.core.urlresolvers import reverse
           % endfor
         </li>
         % endif
+
+## FUN : add links to receipt page
+      <span class="title">
+        <a href="${reverse('payment:list-receipts')}" class="edit-name">
+            ${_("Order History")}
+        </a>
+## END FUN
 
       </ul>
     </section>


### PR DESCRIPTION
EDX doesn't support to display order history when we use ECommerce.
I will try to PR EDX with a fix, so we don't need the fork
