### PR TITLE
Fixes #3890 Exception in course_image_url preventing exports of courses

### DIFF
--- a/openedx/core/lib/courses.py
+++ b/openedx/core/lib/courses.py
@@ -5,26 +5,42 @@ from django.conf import settings
 
 from xmodule.modulestore.django import modulestore
 from xmodule.contentstore.content import StaticContent
-from xmodule.modulestore import ModuleStoreEnum
+from xmodule.modulestore import ModuleStoreEnum as MSE
 
 
 def course_image_url(course):
     """Try to look up the image url for the course.  If it's not found,
     log an error and return the dead link"""
-    if course.static_asset_path or modulestore().get_modulestore_type(course.id) == ModuleStoreEnum.Type.xml:
+    if course.static_asset_path or \
+        modulestore().get_modulestore_type(course.id) == MSE.Type.xml:
         # If we are a static course with the course_image attribute
         # set different than the default, return that path so that
         # courses can use custom course image paths, otherwise just
         # return the default static path.
-        url = '/static/' + (course.static_asset_path or getattr(course, 'data_dir', ''))
-        if hasattr(course, 'course_image') and course.course_image != course.fields['course_image'].default:
+        url = '/static/' + (course.static_asset_path or \
+                getattr(course, 'data_dir', ''))
+        if hasattr(course, 'course_image') and \
+            course.course_image != course.fields['course_image'].default:
             url += '/' + course.course_image
         else:
             url += '/images/course_image.jpg'
-    elif not course.course_image:
+        return url
         # if course_image is empty, use the default image url from settings
-        url = settings.STATIC_URL + settings.DEFAULT_COURSE_ABOUT_IMAGE_URL
-    else:
+
+
+    if course.course_image:
         loc = StaticContent.compute_location(course.id, course.course_image)
         url = StaticContent.serialize_asset_key_with_slash(loc)
+        return url
+    url = ""
+
+    try:
+        url = settings.STATIC_URL + settings.DEFAULT_COURSE_ABOUT_IMAGE_URL
+    except AttributeError as excep:
+        # AttributeError: 'Settings' object has no attribute 'DEFAULT_COURSE_ABOUT_IMAGE_URL'
+        import logging
+        logger = logging.getLogger(__name__)
+        logger.exception("You should check your settings (%r)", excep)
+
     return url
+


### PR DESCRIPTION
   When some settings are not correct for the default image location
   the course_url is raising an exception thus blocking exports of courses.

Solution: instead of crashing log, and also maybe return when
we already have the information

Solves the problem of export courses that raises following error:

AttributeError: 'Settings' object has no attribute 'DEFAULT_COURSE_ABOUT_IMAGE_URL'
  File "django/core/handlers/base.py", line 132, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "django/utils/decorators.py", line 145, in inner
    return func(*args, **kwargs)
  File "django/utils/decorators.py", line 145, in inner
    return func(*args, **kwargs)
  File "django/contrib/auth/decorators.py", line 22, in _wrapped_view
    return view_func(request, *args, **kwargs)
  File "django/utils/decorators.py", line 110, in _wrapped_view
    response = view_func(request, *args, **kwargs)
  File "django/views/decorators/http.py", line 45, in inner
    return func(request, *args, **kwargs)
  File "util/json_request.py", line 52, in parse_json_into_request
    return view_function(request, *args, **kwargs)
  File "contentstore/views/course.py", line 958, in settings_handler
    'course_image_url': course_image_url(course_module),
  File "openedx/core/lib/courses.py", line 26, in course_image_url
    url = settings.STATIC_URL + settings.DEFAULT_COURSE_ABOUT_IMAGE_URL
  File "django/conf/__init__.py", line 49, in __getattr__
    return getattr(self._wrapped, name)