### PR TITLE
Val 20170721

### DIFF
--- a/openedx/core/lib/courses.py
+++ b/openedx/core/lib/courses.py
@@ -21,10 +21,22 @@ def course_image_url(course):
             url += '/' + course.course_image
         else:
             url += '/images/course_image.jpg'
-    elif not course.course_image:
+        return url
         # if course_image is empty, use the default image url from settings
-        url = settings.STATIC_URL + settings.DEFAULT_COURSE_ABOUT_IMAGE_URL
-    else:
+
+    if course.course_image:
         loc = StaticContent.compute_location(course.id, course.course_image)
         url = StaticContent.serialize_asset_key_with_slash(loc)
+        return url
+    url = ""
+
+    try:
+        url = settings.STATIC_URL + settings.DEFAULT_COURSE_ABOUT_IMAGE_URL
+    except AttributeError as e:
+        # AttributeError: 'Settings' object has no attribute 'DEFAULT_COURSE_ABOUT_IMAGE_URL'
+        import logging
+        logger = logging.getLogger(__name__)
+        logger.exception("You should check your settings: (%r)" % e)
+
     return url
+


### PR DESCRIPTION
These 2 patches are merge into one since they are loosely related, but a PR upstream should only contain the modification on openedx/core/lib/courses.py

The patch on common/djangoapps/util/json_request.py is a failsafe version of the upstream version.
Will be osboleted by ficus migration.. It is related to numerous UnicodeDecode error.
XXX: I think JsonBadRequest should also be treated the same. 

The patch on course_url seems to appear with weired combination of settings. The patch is agnostic on fixing the settings and just refuses to fail since course_images are not the most important information.
A critical log is added for informing sysadmins and dev a problem exists.

solves: 
- some impossibility to export lessons
- the impossibility to preview some courses if they are not opened "the right way", and especially, if course_image has accents in its filename (which is fixed by json_request patch). 


