### PR TITLE
Converging with openedx master to install ora2 without conflict

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -53,7 +53,7 @@ networkx==1.7
 nose-xunitmp==0.3.2
 oauthlib==0.7.2
 paramiko==1.9.0
-path.py==7.2
+path.py==8.2.1
 Pillow==2.7.0
 polib==1.0.3
 pycrypto>=2.6

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -2,6 +2,6 @@
 Paver==1.2.4
 psutil==1.2.1
 lazy==1.1
-path.py==7.2
+path.py==8.2.1
 watchdog==0.7.1
 python-memcached


### PR DESCRIPTION
https://github.com/edx/edx-platform/commit/01239ab86cdfd92a905a2800660f683e5cfc4c23

-chardet (3.0.3)
+chardet (3.0.4)
-decorator (4.0.11)
+decorator (4.1.2)
-django-babel (0.6.0)
+django-babel (0.6.1)
-fuzzywuzzy (0.15.0)
+fuzzywuzzy (0.15.1)
-logilab-common (1.4.0)
+logilab-common (1.4.1)
-oauth2client (4.1.1)
+oauth2client (4.1.2)
-pbr (3.0.1)
+pbr (3.1.1)
-simplejson (3.10.0)
+simplejson (3.11.1)
-WebOb (1.7.2)
+WebOb (1.7.3)