### PR TITLE
feature(videofront): Disable studio videofront menu when using Youtub…

### DIFF
--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -67,9 +67,11 @@
                   </li>
 
                   ### FUN: Add a button to our video upoader
+                  % if getattr(settings, 'FUN_DEFAULT_VIDEO_PLAYER', None) is not None:
                   <li class="nav-item nav-course-courseware-videos">
                     <a href="${reverse('videoupload:home', kwargs={'course_key_string': unicode(course_key)})}">${_("Video Uploads")}</a>
                   </li>
+                  % endif
 
                 </ul>
               </div>


### PR DESCRIPTION
Sur certaines marques blanches comme mun.ma, on ne souhaite pas utiliser le player Videofront, il faut donc désactiver completement notre player, cela se fait en mettant la constante FUN_DEFAULT_VIDEO_PLAYER à None dans les settings, mais il faut aussi cacher le menu du studio